### PR TITLE
Add string for translating an email validation messge

### DIFF
--- a/vf_de/site_core.php
+++ b/vf_de/site_core.php
@@ -934,6 +934,7 @@ $Definition['Please join my group.'] = 'Bitte tritt meiner <a href="{Url,html}">
 $Definition['Please wait while you are redirected. If you are not redirected, click <a href="%s">here</a>.'] = 'Du wirst jetzt weitergeleitet. Falls dies nicht geschieht, klicke bitte <a href="%s">hier</a>.';
 $Definition['Points'] = 'Punkte';
 $Definition['Poll'] = 'Umfrage';
+$Definition['poll'] = 'Umfrage';
 $Definition['Poll Options'] = 'Umfrageoptionen';
 $Definition['Poll Question'] = 'Frage';
 $Definition['Popular'] = 'Populär';

--- a/vf_de/site_core.php
+++ b/vf_de/site_core.php
@@ -1220,6 +1220,7 @@ $Definition['The email you have entered is already related to an existing accoun
 $Definition['The file failed to upload.'] = 'Fehler beim Hochladen der Datei.';
 $Definition['their'] = 'ihr';
 $Definition['The name you entered is already in use by another member.'] = 'Der angegebene Name wird von einem anderen Nutzer bereits verwendet.';
+$Definition['The email you entered is in use by another member.'] = 'Die eingegebene E-Mail-Adresse wird bereits von einem anderen Mitglied verwendet.';
 $Definition['The page you were looking for could not be found.'] = 'Die gewünschte Seite konnte nicht gefunden werden.';
 $Definition['The quote had to be converted from %s to %s.'] = 'Das Zitat musste von %s zu %s geändert werden. Einige Formatierungen könnten dabei verloren gegangen sein.';
 $Definition['There\'s already a %s with the name %s.'] = 'Es gibt bereits ein %1$s mit dem Namen %2$s. ';
@@ -1463,9 +1464,9 @@ $Definition['You can use HTML in your signature.'] = 'Du kannst <b><a href="http
 $Definition['You don\'t have permission to do that.'] = 'Du hast keine Berechtigung hierfür.';
 $Definition['You don\'t have permission to use a signature.'] = 'Du hast nicht die Berechtigungen, eine Signatur zu verwenden.';
 $Definition['You do not have any %s yet.'] = 'Du hast noch keine %s.';
-$Definition['You do not have any bookmarks.'] = 'Du hast keine Lesezeichen.';
+$Definition['You do not have any bookmarks.'] = 'Du hast noch keine Lesezeichen.';
 $Definition['You do not have any conversations.'] = 'Du hast noch keine Konversationen.';
-$Definition['You do not have any drafts.'] = 'Du hast keine Entwürfe.';
+$Definition['You do not have any drafts.'] = 'Du hast noch keine Entwürfe.';
 $Definition['You do not have any notifications yet.'] = 'Du hast noch keine Benachrichtigungen.';
 $Definition['You do not have enough invitations left.'] = 'Du hast nicht genügend Einladungen übrig.';
 $Definition['You do not have permission to edit all of the posts you are trying to merge.'] = 'Sie haben nicht die Erlaubnis, alle Beiträge zu bearbeiten, die Sie einzufügen versuchen.';

--- a/vf_es/site_core.php
+++ b/vf_es/site_core.php
@@ -961,6 +961,7 @@ $Definition['Please join my group.'] = 'Por favor, únete a mi <a href="{Url,htm
 $Definition['Please wait while you are redirected. If you are not redirected, click <a href="%s">here</a>.'] = 'Por favor espera mientras te redireccionamos. Si no eres redireccionado, haz click <a href="%s">aquí</a>.';
 $Definition['Points'] = 'Puntos ';
 $Definition['Poll'] = 'Encuesta';
+$Definition['poll'] = 'Encuesta';
 $Definition['Poll Options'] = 'Opciones de la encuesta';
 $Definition['Poll Question'] = 'Preguntas de la encuesta';
 $Definition['Popular Discussions'] = 'Hilos Populares';

--- a/vf_es/site_core.php
+++ b/vf_es/site_core.php
@@ -1248,6 +1248,7 @@ $Definition['The email you have entered is already related to an existing accoun
 $Definition['The file failed to upload.'] = 'El archivo falló al subirlo.';
 $Definition['their'] = 'su';
 $Definition['The name you entered is already in use by another member.'] = 'El nombre que escribiste está siendo usado por otro usuario.';
+$Definition['The email you entered is in use by another member.'] = 'El correo electrónico que has introducido está en uso por otro miembro.';
 $Definition['The page you were looking for could not be found.'] = 'La página que estabas buscando no se ha encontrado';
 $Definition['The quote had to be converted from %s to %s.'] = 'La cita se tubo que convertir de %s a %s. Algunos formatos se pueden haber perdido.';
 $Definition['There\'s already a %s with the name %s.'] = 'Ya hay un %1$s con el nombre %2$s.';

--- a/vf_fr/site_core.php
+++ b/vf_fr/site_core.php
@@ -917,6 +917,7 @@ $Definition['Play the sound again'] = 'Jouer le son à nouveau';
 $Definition['Please join my group.'] = 'Merci de joindre mon <a href="{Url,html}">groupe</a>.';
 $Definition['Please wait while you are redirected. If you are not redirected, click <a href="%s">here</a>.'] = 'Vous allez être redirigé. Si vous n\'êtes pas redirigé, cliquez <a href="%s">ici</a>.';
 $Definition['Poll'] = 'Sondage';
+$Definition['poll'] = 'Sondage';
 $Definition['Poll Options'] = 'Options de sondage';
 $Definition['Poll Question'] = 'Question de sondage';
 $Definition['Popular'] = 'Populaire';

--- a/vf_fr/site_core.php
+++ b/vf_fr/site_core.php
@@ -1192,6 +1192,7 @@ $Definition['The email you have entered is already related to an existing accoun
 $Definition['The file failed to upload.'] = 'Le fichier n\'a pu être envoyé.';
 $Definition['their'] = 'leur';
 $Definition['The name you entered is already in use by another member.'] = 'Le nom que vous avez entré est déjà utilisé par un autre membre.';
+$Definition['The email you entered is in use by another member.'] = 'L\'adresse e-mail saisie est déjà utilisée par un autre membre.';
 $Definition['The page you were looking for could not be found.'] = 'La page que vous recherchez n\'a pu être trouvée.';
 $Definition['The quote had to be converted from %s to %s.'] = 'La citation a dû être transformée de %s à %s. Des éléments de formatage ont peut-être été perdus.';
 $Definition['There\'s already a %s with the name %s.'] = 'Il y a déjà un %1$s avec comme nom %2$s.';


### PR DESCRIPTION
When someone tries to connect to the site via SSO and they enter an email that is already taken, this string appears (/entry/connect)