### PR TITLE
Remove exit from dash core and site core

### DIFF
--- a/tx-source/dash_core.php
+++ b/tx-source/dash_core.php
@@ -1,4 +1,4 @@
-<?php if (!defined('APPLICATION')) exit();
+<?php 
 $Definition['%1$s "%2$s" not found.'] = '%1$s "%2$s" not found.';
 $Definition['%1$s %2$s'] = '%1$s %2$s';
 $Definition['%1$s Version %2$s'] = '%1$s Version %2$s';

--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -1,4 +1,4 @@
-<?php if (!defined('APPLICATION')) exit();
+<?php 
 $Definition[' - Page %s'] = ' - Page %s';
 $Definition[' now.'] = ' now.';
 $Definition['%1$s accepted %4$s invitation for membership.'] = '%1$s accepted %4$s invitation for membership.';


### PR DESCRIPTION
Gdn_Configuration adds the `if (!defined('APPLICATION')) exit()` block to the top of a configuration file by default. Localligator uses Gdn_Configuration to update locale files. This removes the exit() command, which was messing badly with txsync.

Will be permanently fixed with https://github.com/vanilla/internal/pull/826