### PR TITLE
Translate plural of polls for the advanced search

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -947,6 +947,8 @@ $Definition['Please wait while you are redirected. If you are not redirected, cl
 $Definition['Points'] = 'Points';
 $Definition['Poll'] = 'Poll';
 $Definition['poll'] = 'Poll';
+$Definition['Polls'] = 'Polls';
+$Definition['polls'] = 'Polls';
 $Definition['Poll Options'] = 'Poll Options';
 $Definition['Poll Question'] = 'Poll Question';
 $Definition['Popular'] = 'Popular';


### PR DESCRIPTION
The arenanet guys noticed that the polls checkbox is not translated in the advanced search plugin, this translation adds a pluralized version of the word polls for that section.