### PR TITLE
Add a translation for the register page

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -553,6 +553,7 @@ $Definition['Following %d people'] = 'Following %d people';
 $Definition['Following %d person'] = 'Following %d person';
 $Definition['FollowOnly'] = 'Follow the link below to check it out:';
 $Definition['Follows'] = 'Follows';
+$Definition['For a stronger password, increase its length or combine upper and lowercase letters, digits, and symbols.' = 'For a stronger password, increase its length or combine upper and lowercase letters, digits, and symbols.';
 $Definition['Forgot your password?'] = 'Forgot your password?';
 $Definition['Forgot?'] = 'Forgot?';
 $Definition['Format'] = 'Format';


### PR DESCRIPTION
This line already has a translate tag, but there is no translation for it.

Shown [here](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/views/entry/registerbasic.php#L36)