### PR TITLE
Add extra string to locale source

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -555,6 +555,7 @@ $Definition['expires %s'] = 'expires %s';
 $Definition['Failed to delete group.'] = 'Failed to delete group.';
 $Definition['Failed to find discussion for commenting.'] = 'Failed to find discussion for commenting.';
 $Definition['Failed to load the poll.'] = 'Failed to load the poll.';
+$Definition['Favorites'] = 'Favorites';
 $Definition['Feedback'] = 'Feedback';
 $Definition['Female'] = 'Female';
 $Definition['Fifth Anniversary'] = 'Fifth Anniversary';

--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -350,6 +350,7 @@ $Definition['Comments'] = 'Comments';
 $Definition['comments'] = 'comments';
 $Definition['Comments are between {UserID,you}.'] = 'Comments are between {UserID,you}.';
 $Definition['Community'] = 'Community';
+$Definition['Community Home'] = 'Community Home';
 $Definition['Community Guidelines'] = 'Community Guidelines';
 $Definition['Completed'] = 'Completed';
 $Definition['Completely delete the warning.'] = 'Completely delete the warning.';


### PR DESCRIPTION
The 'Community Home' string is most notably found in the Lithe Mobile theme sidebar, but it seems to be coming from here precisely: https://github.com/vanilla/vanilla/blob/32fe13d05dee9dc2bf731b942a68eba5bd466c5f/applications/dashboard/settings/class.hooks.php#L767