### PR TITLE
Add the string All Statuses to site_core

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -197,6 +197,7 @@ $Definition['All Events'] = 'All Events';
 $Definition['All Members'] = 'All Members';
 $Definition['All members'] = 'All members';
 $Definition['All Notifications'] = 'All Notifications';
+$Definition['All Statuses'] = 'All Statuses';
 $Definition['Allow'] = 'Allow';
 $Definition['Allow other members to see your email?'] = 'Allow other members to see your email?';
 $Definition['All Time Leaders'] = 'All Time Leaders';


### PR DESCRIPTION
As part of uncoupling All %s Nouns which translate poorly.