### PR TITLE
Translation key for forgot password wrong email

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -387,6 +387,7 @@ $Definition['conversation'] = 'conversation';
 $Definition['Copy'] = 'Copy';
 $Definition['Core'] = 'Core';
 $Definition['Couldn\'t confirm email.'] = 'Couldn\'t confirm email.';
+$Definition['Couldn\'t find an account associated with that email/username.'] = 'Couldn\'t find an account associated with that email/username.';
 $Definition['Created'] = 'Created';
 $Definition['Create an Account'] = 'Create an Account';
 $Definition['Create Discussions'] = 'Create Discussions';


### PR DESCRIPTION
<!---
Thanks for filing an issue 😄 ! Before you submit, please read the following:

Translations in this repository are managed by Transifex https://transifex.com/vanilla/vanilla. To contribute translations, please create an account on Transifex.com and request access to a team via the Vanilla Forums Community Forum https://vanillaforums.org/discussions. We'd love your help!

To add a new source string in `tx-source` please proceed with the template below.
-->

<!--- Please explain below where in the Vanilla Forums product or repos this translation string will be used.

If the string is not present in one of Vanilla's github repos it likely doesn't belong in this repo. Instead it can be added directly in your addon! https://docs.vanillaforums.com/developer/locales/#overriding-locales
-->

## New or changed source translation strings

| Source String                | Location or PR in a Vanilla repository
|------------------------------|----------------------------------------
|    'Couldn\'t find an account associated with that email/username.'                          |tx-source/site_core.php
