### PR TITLE
Add error messages used on editor plugin

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -481,6 +481,9 @@ $Definition['editor.HtmlHelpText'] = 'You can use <a href="http://htmlguide.drgr
 $Definition['editor.MarkdownHelpText'] = 'You can use <a href="http://en.wikipedia.org/wiki/Markdown" target="_new">Markdown</a> in your post.';
 $Definition['editor.TextHelpText'] = 'You are using plain text in your post.';
 $Definition['editor.WysiwygHelpText'] = 'You are using <a href="https://en.wikipedia.org/wiki/WYSIWYG" target="_new">WYSIWYG</a> in your post.';
+$Definition['editor.fileErrorSize'] = 'File size is too large.'
+$Definition['editor.fileErrorFormat'] = 'File format is not allowed.'
+$Definition['editor.fileErrorSizeFormat'] = 'File size is too large and format is not allowed.'
 $Definition['Edit Preferences'] = 'Edit Preferences';
 $Definition['Edit Profile'] = 'Edit Profile';
 $Definition['Edit Tag'] = 'Edit Tag';


### PR DESCRIPTION
> Please explain below where in the Vanilla Forums product or repos this translation string will be used.

https://github.com/vanilla/vanilla/pull/7144/files

## New or changed source translation strings

| Source String                | Location or PR in a Vanilla repository
|------------------------------|----------------------------------------
|  editor.fileErrorSize  | https://github.com/vanilla/vanilla/pull/7144
|  editor.fileErrorFormat | https://github.com/vanilla/vanilla/pull/7144
|  editor.fileErrorSizeFormat | https://github.com/vanilla/vanilla/pull/7144
