### PR TITLE
Removed message for no group invites

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -924,7 +924,6 @@ $Definition['Nobody is on the fence right now.'] = 'Nobody is on the fence right
 $Definition['No default roles.'] = 'No default roles.';
 $Definition['No discussions were found.'] = 'No discussions were found.';
 $Definition['No items tagged with %s.'] = 'No items tagged with %s.';
-$Definition['There aren\'t any more groups invites.'] = 'There aren\'t any more groups invites.';
 $Definition['None'] = 'None';
 $Definition['NoPermissionToDeleteDiscussions'] = 'You do not have permission to delete %1$s of the selected discussions.';
 $Definition['No results'] = 'No results';


### PR DESCRIPTION
Removed this string, since it's not longer used: https://github.com/vanilla/internal/pull/1677