### PR TITLE
adding translation key for poll's "View Results"

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -1527,6 +1527,7 @@ $Definition['Video embedding has been disabled.'] = 'Video embedding has been di
 $Definition['View'] = 'View';
 $Definition['View Badge'] = 'View Badge';
 $Definition['View Post'] = 'View Post';
+$Definition['View Results'] = 'View Results';
 $Definition['Viewing'] = 'Viewing';
 $Definition['Views'] = 'Views';
 $Definition['Visible'] = 'Visible';


### PR DESCRIPTION
<!---
Thanks for filing an issue 😄 ! Before you submit, please read the following:

Translations in this repository are managed by Transifex https://transifex.com/vanilla/vanilla. To contribute translations, please create an account on Transifex.com and request access to a team via the Vanilla Forums Community Forum https://vanillaforums.org/discussions. We'd love your help!

To add a new source string in `tx-source` please proceed with the template below.
-->

<!--- Please explain below where in the Vanilla Forums product or repos this translation string will be used.

If the string is not present in one of Vanilla's github repos it likely doesn't belong in this repo. Instead it can be added directly in your addon! https://docs.vanillaforums.com/developer/locales/#overriding-locales
-->

## New or changed source translation strings

| Source String                | Location or PR in a Vanilla repository
|------------------------------|----------------------------------------
|           View Results                   | [Polls/views/form.php#L32](https://github.com/vanilla/internal/blob/master/plugins/Polls/views/form.php#L32)
