### PR TITLE
Add error message when article associated to draft can't be found

### DIFF
--- a/tx-source/site_kb.php
+++ b/tx-source/site_kb.php
@@ -118,6 +118,7 @@ $Definition["This article has been deleted."] = "This article has been deleted."
 $Definition["This article hasn't been translated yet."] = "This article hasn't been translated yet.";
 $Definition["This article hasn't been translated yet. The original article text has been loaded to aid translation."] = "This article hasn't been translated yet. The original article text has been loaded to aid translation.";
 $Definition['This article is not translated yet or it is out of date.'] = 'This article is not translated yet or it is out of date.';
+$Definition['The article this draft is based on is no longer available.'] = 'The article this draft is based on is no longer available.';
 $Definition['This article was edited in its source locale on <0/>. Edit this article to update its translation and clear this message.'] = 'This article was edited in its source locale on <0/>. Edit this article to update its translation and clear this message.';
 $Definition['This article was edited in its source locale. Edit this article to update its translation and clear this message.'] = 'This article was edited in its source locale. Edit this article to update its translation and clear this message.';
 $Definition["This category does not have any articles."] = "This category does not have any articles.";


### PR DESCRIPTION
Added the error message related when trying to edit a draft and the article it's based off can't be found.

`The article this draft is based on is no longer available.`

related to https://github.com/vanilla/knowledge/pull/1374