### PR TITLE
Add products string to site_core

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -1171,6 +1171,7 @@ $Definition['Private group.'] = 'Anyone can see the group, but only members can 
 $Definition['Private Note for Moderators'] = 'Private Note for Moderators';
 $Definition['Problem with credentials.'] = 'Problem with credentials.';
 $Definition['Proceed'] = 'Proceed';
+$Definition['Products'] = 'Products';
 $Definition['Profile'] = 'Profile';
 $Definition['Profile Fields'] = 'Profile Fields';
 $Definition['Profile  Fields'] = 'Profile  Fields';


### PR DESCRIPTION
Closes vanilla/support#1860

This PR adds the "Products" string to site_core, which had been missing.