### PR TITLE
Add 'code block' key and string

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -1908,6 +1908,7 @@ $Definition['Format as Strikethrough'] = 'Format as Strikethrough';
 $Definition['Strikethrough'] = 'Strikethrough';
 $Definition['Format as Inline Code'] = 'Format as Inline Code';
 $Definition['Paragraph Code Block'] = 'Code Block';
+$Definition['Code Block'] = 'Code Block';
 $Definition['Format as Link'] = 'Format as Link';
 $Definition['Link'] = 'Link';
 $Definition['Insert Url'] = 'Insert Url';


### PR DESCRIPTION
Partially addresses vanilla/support#1863.

The string 'code block' wasn't getting translated in the rich editor paragraph editing menu because the code wasn't in transifex (although the string is already translated). This PR adds the key-value combo, so that it will be translated in other languages.