### PR TITLE
Add invite locale

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -844,6 +844,7 @@ $Definition['Invite Members'] = 'Invite Members';
 $Definition['Invite one or more people to join this group.'] = 'Invite one or more people to join this group.';
 $Definition['IPAddress'] = 'IPAddress';
 $Definition['IP Address'] = 'IP Address';
+$Definition['I confirm that I have permission to use the email addresses provided.'] = 'I confirm that I have permission to use the email addresses provided.';
 $Definition['I remember now!'] = 'I remember now!';
 $Definition['Italic'] = 'Italic';
 $Definition['Item'] = 'Item';


### PR DESCRIPTION
This is for the issue [#2781](https://github.com/vanilla/support/issues/2781), it's related to the PR [#1152](https://github.com/vanilla/vanilla-cloud/pull/1152). The CMS agent made a comment in the issue that there was no locale for the text. 

