### PR TITLE
Remove reference to JSONP from JSConnect settings page.

### DIFF
--- a/tx-source/dash_text.php
+++ b/tx-source/dash_text.php
@@ -202,7 +202,7 @@ $Definition['The database user you specified does not have permission to access 
 $Definition['The following structure changes are required for your database.'] = 'The following structure changes are required for your database.';
 $Definition['The import file does not contain any data.'] = 'The import file does not contain any data.';
 $Definition['The import file is not in the correct format.'] = 'The import file is not in the correct format.';
-$Definition['The location of the jsonp formatted authentication data.'] = 'The location of the jsonp formatted authentication data.';
+$Definition['The location of the authentication endpoint.'] = 'The location of the authentication endpoint.';
 $Definition['ThemeHelp'] = 'Themes allow you to change the look &amp; feel of your site.<br />Once a theme has been added to your %s folder, you can enable it here.';
 $Definition['Theme preview is limited to displaying the theme\'s template and css.'] = 'Theme preview is limited to displaying the theme\'s template and css.';
 $Definition['The Password Authenticator does not have any custom configuration options. '] = 'The Password Authenticator does not have any custom configuration options. ';


### PR DESCRIPTION
In JSConnect V2 we authenticate by accessing an endpoint on the authentication server that responds with a JSONP response. Although this method is deprecated we continue to reference it in the instructions of the settings form of JSConnect, causing some confusion.

This PR replaces the line "The location of the JSONP formatted authentication data." with "The location of the authentication endpoint."

See https://github.com/vanilla/vanilla-cloud/pull/3059