### PR TITLE
Add missing string from the ignore plugin

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -1700,6 +1700,7 @@ $Definition['Type your comment'] = 'Type your comment';
 $Definition['Type your message'] = 'Type your message';
 $Definition['Type or paste emails separated by commas.'] = 'Type or paste emails separated by commas.';
 
+$Definition['Unable to create conversation, %s is ignoring you.'] = 'Unable to create conversation, %s is ignoring you.';
 $Definition['Unable to send message, %s is ignoring you.'] = 'Unable to send message, %s is ignoring you.';
 $Definition['Unannounce'] = 'Unannounce';
 $Definition['Unanswered'] = 'Unanswered';


### PR DESCRIPTION
Closes vanilla/support#4537

This PR adds a string that was missing from our locales source files.