### PR TITLE
Adding "Invalid user/password provided." string for translation.

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -1790,6 +1790,7 @@ $Definition['{Username} has requested to join {Group}.'] = '{Username} has reque
 $Definition['Username or email'] = 'Username or email';
 $Definition['User Not Found'] = 'User Not Found';
 $Definition['User not found.'] = 'Sorry, no account could be found related to the email/username you entered.';
+$Definition['Invalid user/password provided.'] = 'Invalid user/password provided.';
 $Definition['Users'] = 'Users';
 $Definition['Users Count'] = 'Users Count';
 $Definition['Use up to {maxImages,plural,%s image, %s images}.'] = 'Use up to {maxImages,plural,%s image, %s images}.';


### PR DESCRIPTION
This PR adds strings for the following PR: https://github.com/vanilla/vanilla-cloud/pull/4428
And is related to the following issue: [VNLA-1133](https://higherlogic.atlassian.net/browse/VNLA-1133)