### PR TITLE
APPENG-18390 - Adds ideation email headline

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -775,6 +775,7 @@ $Definition['HeadlineFormat.Ban'] = '{RegardingUserID,You} banned {ActivityUserI
 $Definition['HeadlineFormat.Comment'] = '{ActivityUserID,user} commented on <a href="{Url,html}">{Data.Name,text}</a>';
 $Definition['HeadlineFormat.ConversationMessage'] = '{ActivityUserID,User} sent you a <a href="{Url,html}">message</a>';
 $Definition['HeadlineFormat.Discussion'] = '{ActivityUserID,user} Started a new discussion. <a href="{Url,html}">{Data.Name,text}</a>';
+$Definition['HeadlineFormat.Discussion.Idea'] = '{ActivityUserID,user} Started a new idea in {Data.Category}: <a href="{Url,html}">{Data.Name,text}</a>';
 $Definition['HeadlineFormat.Discussion.Poll'] = '{ActivityUserID,user} started a new poll in {Data.Category}: <a href="{Url,html}">{Data.Name,text}</a>';
 $Definition['HeadlineFormat.Discussion.Question'] = '{ActivityUserID,user} posted a new question in {Data.Category}: <a href="{Url,html}">{Data.Name,text}</a>';
 $Definition['HeadlineFormat.Mention'] = '{ActivityUserID,user} mentioned you in <a href="{Url,html}">{Data.Name,text}</a>';


### PR DESCRIPTION
Adds the idea-specific category notification locale.

The code already handles HeadlineFormat.Discussion.{TYPE} for idea, question, polls but idea was never explicitly added into locales. This corrects that oversight.