### PR TITLE
VNLA-2741 translations

### DIFF
--- a/tx-source/dash_core.php
+++ b/tx-source/dash_core.php
@@ -378,6 +378,7 @@ $Definition['Failure'] = 'Failure';
 $Definition['Favicon'] = 'Favicon';
 $Definition['FaviconBrowse'] = 'Browse for a new favicon if you would like to change it:';
 $Definition['FaviconDescription'] = "Your site's favicon appears in your browser's title bar. It will be scaled down appropriately.";
+$Definition['Field is required.'] = 'Field is required.';
 $Definition['FileUpload is currently OFF'] = 'FileUpload is currently OFF';
 $Definition['FileUpload is currently ON'] = 'FileUpload is currently ON';
 $Definition['Filter'] = 'Filter';


### PR DESCRIPTION
Related to ticket: https://higherlogic.atlassian.net/browse/VNLA-2941 
Related to PR: https://github.com/vanilla/vanilla-cloud/pull/5530

Adds translation for "Field is required." for tooltip text in widget settings form.