### PR TITLE
VNLA-3085: Add translation strings for profile field options for webhooks.

### DIFF
--- a/tx-source/dash_core.php
+++ b/tx-source/dash_core.php
@@ -446,6 +446,8 @@ $Definition['If enabled, the full content of posts will be sent in email notific
 $Definition['Inbox Page'] = 'Inbox Page';
 $Definition['Include Child Categories'] = 'Include Child Categories';
 $Definition['Include full post in email notifications'] = 'Include full post in email notifications';
+$Definition['Include internal profile fields'] = 'Include internal profile fields';
+$Definition['Include private profile fields'] = 'Include private profile fields';
 $Definition['Include Subcategories'] = 'Include Subcategories';
 $Definition['Include Subdomains'] = 'Include Subdomains';
 $Definition['Indexes'] = 'Indexes';

--- a/tx-source/dash_text.php
+++ b/tx-source/dash_text.php
@@ -260,6 +260,8 @@ $Definition['Warning: This is for advanced users.'] = '<b>Warning</b>: This is f
 $Definition['Webhooks'] = 'Webhooks';
 $Definition['We recommend mostly positive reactions to encourage participation.'] = 'We recommend mostly positive reactions to encourage participation.';
 $Definition['When enabled, you can manage products, and group subcommunities by those products.'] = 'When enabled, you can manage products, and group subcommunities by those products.';
+$Definition['Whether or not the internal profile fields will be included in this webhook.'] = 'Whether or not the internal profile fields will be included in this webhook.';
+$Definition['Whether or not the private profile fields will be included in this webhook.'] = 'Whether or not the private profile fields will be included in this webhook.';
 $Definition['Which reactions you use really depends on your community.'] =
     'Which reactions you use really depends on your community, but we recommend keeping a couple of points in mind.';
 


### PR DESCRIPTION
Issue: https://higherlogic.atlassian.net/browse/VNLA-3085

Adds translation strings for the options for including internal and private profile fields in webhook deliveries.

Goes with this vanilla-cloud PR: https://github.com/vanilla/vanilla-cloud/pull/5682