### PR TITLE
VNLA-6414: Add translation string for Zendesk sync

### DIFF
--- a/tx-source/dash_core.php
+++ b/tx-source/dash_core.php
@@ -105,6 +105,7 @@ $Definition['Allow users to change their own avatars'] = 'Allow users to change 
 $Definition['Allow users to dismiss this message'] = 'Allow users to dismiss this message.';
 $Definition['All Pages'] = 'All Pages';
 $Definition['An enabled message will be visible on the site.'] = 'An enabled message will be visible on the site.';
+$Definition['An answer in this the community thread was marked as accepted'] = 'An answer in this the community thread was marked as accepted';
 $Definition['Anonymize Analytics Data by Default'] = 'Anonymize Analytics Data by Default';
 $Definition['API'] = 'API';
 $Definition['API Label is required'] = 'API Label is required';


### PR DESCRIPTION
This PR adds a string that's part of https://github.com/vanilla/vanilla-cloud/pull/7668.