### PR TITLE
VNLA-7370: Implement Event notification locale headlines

### DIFF
--- a/tx-source/site_core.php
+++ b/tx-source/site_core.php
@@ -2468,3 +2468,8 @@ $Definition["Read More"] = "Read More";
 $Definition["Hello,\n\nAn account has been created for you at the %s forum.\n\n"] = "Hello,\n\nAn account has been created for you at the %s forum.\n\n";
 $Definition["To activate your account, please follow this link:\n%s\n\n"] = "To activate your account, please follow this link:\n%s\n\n";
 $Definition["Please contact us if you have questions regarding this email.\n\nSincerely,\n%s"] = "Please contact us if you have questions regarding this email.\n\nSincerely,\n%s";
+
+// Event
+$Definition["HeadlineFormat.EventReminder"] = "Reminder: {Data.Name,text} begins in 1 day";
+$Definition["HeadlineFormat.NewEvent"] = "New Event: {Data.Name,text}";
+$Definition["HeadlineFormat.UpdatedEvent"] = "Updated Event: {Data.Name,text}";


### PR DESCRIPTION
# Issue

Event notification headlines are not editable.

See: https://higherlogic.atlassian.net/browse/VNLA-7370

See: https://github.com/vanilla/vanilla-cloud/pull/8372

# Changes

Add a proper code to translate event notification headlines.
